### PR TITLE
Restructured initialization files

### DIFF
--- a/common-config.org
+++ b/common-config.org
@@ -124,13 +124,6 @@
    #+BEGIN_SRC emacs-lisp
      (setq initial-scratch-message "")
    #+END_SRC
-** Run shell commands interactively when under Cygwin shell
-   As found on [[https://emacs.stackexchange.com/a/10974/14110][StackExchange]]:
-   #+BEGIN_SRC emacs-lisp
-     (when (eq system-type 'cygwin)
-       (setq shell-file-name "bash")
-       (setq shell-command-switch "-ic"))
-   #+END_SRC
 ** =dired= tweaks
 *** Set =dired-dwim-target=
     #+BEGIN_SRC emacs-lisp
@@ -305,7 +298,6 @@
       :init
       (add-hook 'csv-mode-hook 'display-line-numbers))
   #+END_SRC
-
 * Install =which-key=
   #+BEGIN_SRC emacs-lisp
     (use-package which-key

--- a/emacs-init.org
+++ b/emacs-init.org
@@ -230,29 +230,22 @@
 						 ("reddit\\.com" . markdown-mode)))
 	(atomic-chrome-start-server)))
   #+end_src
-* Set the default browser
-** Use =Firefox= as the default browser when running in Cygwin
-   #+begin_src emacs-lisp
-     (when (eq system-type 'cygwin)
-       (setq browse-url-browser-function (lambda (URL &rest ARGS)
-					   (shell-command (concat "cygstart firefox " URL)))))
-   #+end_src
-** Also use =Firefox= as the default browser when running in =Windows Subsystem for Linux=
-   In =WSL= the variable =system-type= is set to =gnu/linux= which is the same value for =Ubuntu= so this cannot be used to check if running in =WSL=. Luckily this [[https://emacs.stackexchange.com/a/55295/14110][StackExchange answer]] provides the solution: check for variable =operating-system-release=.
-   In =WSL1= its value ends in =-Microsoft= and in =WSL2= it ends in =-microsoft-standard=.
-   #+begin_src emacs-lisp
-     (defun rp/browse-url-firefox(url &rest args)
-       "Browse URL using Firefox from Windows when running under WSL.
-     This function calls `shell-command' to pass URL to the Firefox browser located at `/mnt/c/Program\\ Files/Mozilla\\ Firefox/firefox.exe'.
-     "
-       (progn
-	 (message "Browsing URL [%s] using external Firefox." url)
-	 (shell-command
-	  (concat "/mnt/c/Program\\ Files/Mozilla\\ Firefox/firefox.exe "
-		  url))))
+* Use =Firefox= as the default browser when running in =Windows Subsystem for Linux=
+  In =WSL= the variable =system-type= is set to =gnu/linux= which is the same value for =Ubuntu= so this cannot be used to check if running in =WSL=. Luckily this [[https://emacs.stackexchange.com/a/55295/14110][StackExchange answer]] provides the solution: check for variable =operating-system-release=.
+  In =WSL1= its value ends in =-Microsoft= and in =WSL2= it ends in =-microsoft-standard=.
+  #+begin_src emacs-lisp
+    (defun rp/browse-url-firefox(url &rest args)
+      "Browse URL using Firefox from Windows when running under WSL.
+    This function calls `shell-command' to pass URL to the Firefox browser located at `/mnt/c/Program\\ Files/Mozilla\\ Firefox/firefox.exe'.
+    "
+      (progn
+	(message "Browsing URL [%s] using external Firefox." url)
+	(shell-command
+	 (concat "/mnt/c/Program\\ Files/Mozilla\\ Firefox/firefox.exe "
+		 url))))
 
-     (when (string-match "-[Mm]icrosoft" operating-system-release)
-       (progn
-	 (message "Running under WSL. The browse-url-browser-function will be overwritten.")
-	 (setq browse-url-browser-function 'rp/browse-url-firefox)))
-   #+end_src
+    (when (string-match "-[Mm]icrosoft" operating-system-release)
+      (progn
+	(message "Running under WSL. The browse-url-browser-function will be overwritten.")
+	(setq browse-url-browser-function 'rp/browse-url-firefox)))
+  #+end_src

--- a/emacs-init.org
+++ b/emacs-init.org
@@ -147,12 +147,6 @@
       (use-package org-pdfview
 	:ensure t))
   #+END_SRC
-* Install =powershell=
-  #+BEGIN_SRC emacs-lisp
-    (use-package powershell
-      :ensure t
-      :defer t)
-  #+END_SRC
 * Install =ledger-mode=
 ** Prerequisites
    Requires =ledger= to be installed:
@@ -223,15 +217,6 @@
       (progn
 	(setq org-re-reveal-root "http://cdn.jsdelivr.net/reveal.js/3.0.0/")))
   #+END_SRC
-* Install =auto-package-update=
-  #+begin_src emacs-lisp
-    (use-package auto-package-update
-      :ensure t
-      :disabled
-      :config
-      (setq auto-package-update-prompt-before-update t)
-      (auto-package-update-maybe))
-  #+end_src
 * Install =atomic-chrome= to edit text areas in Emacs
   [[https://github.com/alpha22jp/atomic-chrome][Atomic chrome]] allows editing text from a text area within browser using Emacs. Since I use Firefox I [[https://github.com/GhostText/GhostText][GhostText extension]] needs to be installed in Firefox in order for this to work.
   #+begin_src emacs-lisp


### PR DESCRIPTION
Since the structure of the initialization packages was getting out of hand this PR was created to take care of that.

Main changes:
- `emacs-init.org` and `common-config.org` were merged into a single `emacs-init.org` file
- removed `java-config.org` because Java development will be done in other IDE for now
- removed some unused packages
- `org` and `org-contrib` packages are installed from ELPA and nonGNU ELPA
- upgraded `org-ref` to version 3
- reinstalled all packages in `elpa/` directory in order to make sure no unused packages are kept.